### PR TITLE
[slides] add nfdi4ing logo

### DIFF
--- a/slides/index.css
+++ b/slides/index.css
@@ -44,3 +44,12 @@ pre {
     width: 128px;
     aspect-ratio: 1 / 1;
 }
+
+.nfdi4ing-icon {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+
+    width: 128px;
+    aspect-ratio: 1 / 1;
+}

--- a/slides/index.html
+++ b/slides/index.html
@@ -16,6 +16,7 @@
     </head>
     <body>
         <img class="suresoft-icon" src="img/suresoft-icon.png">
+        <img class="nfdi4ing-icon" src="https://www.ulb.tu-darmstadt.de/media/ulb/logos_ulb/Logo_NFDI4Ing_475x0.jpg">
         <div class="reveal">
             <div class="slides">
                 <section id="title-slide">


### PR DESCRIPTION
Currently, the slides only contain suresoft branding, so I added the nfdi4ing logo at the top right corner if you do the workshop in a purely suresoft context, you can just remove it again then....